### PR TITLE
Update textual information for download and share projects

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -23,7 +23,7 @@
             },
             "projects": {
                 "all": "Your existing projects",
-                "nothing": "Nothing to show, create your first project to start using ADNO"
+                "nothing": "Nothing to show, create your first project to start using Adno"
             },
             "project": {
                 "created_on": "Created on ",
@@ -40,7 +40,7 @@
                 "description": "Description",
                 "autor": "Autor",
                 "editor": "Editor",
-                "manifest_url": "Manifest URL",
+                "manifest_url": "URL",
                 "create": "Create my new project",
                 "back": "Back",
                 "add_desc": "Add a little text to describe your project (optional)",
@@ -102,10 +102,10 @@
                 "del_annotation_confirmation": "Annotation deleted successfully",
                 "project_edit_success": "Your project have been updated successfully !",
                 "settings_updated_success": "Settings updated successfully !",
-                "adno_proj_detected": "ADNO project detected, would you like to import it ?",
-                "old_version": "One or more projects were made with an obsolete version of ADNO",
-                "update_old_version": "Update to the latest version of ADNO",
-                "version_updated": "Congratulations, your ADNO projects are now up to date"
+                "adno_proj_detected": "Adno project detected, would you like to import it ?",
+                "old_version": "One or more projects were made with an obsolete version of Adno",
+                "update_old_version": "Update to the latest version of Adno",
+                "version_updated": "Congratulations, your Adno projects are now up to date"
             },
             "annotation": {
                 "no_content": "no content yet",
@@ -117,11 +117,11 @@
                 "download_project": "Download the project",
                 "edit_project": "Edit the project",
                 "show_metadatas": "Show metadatas",
-                "share_project": "Project sharing",
-                "share_project_desc1": "In order to be able to work collaboratively, you must download the project and then share it with your collaborators via a service such as IPFS, Google Drive or WeTransfer.",
-                "share_project_desc2": "Thus, your collaborators will be able to import the project on their side in order to benefit from your changes.",
+                "share_project": "Save and share your project",
+                "share_project_desc1": "First, download your project file. To share it, you can either send it by e-mail, or place it online - on a website, a file server or on the IPFS interplanetary file system - and then share its URL or IPFS CID.",
+                "share_project_desc2": "Once your Adno project is online, you can make it visible on a web page by inserting an iframe tag. ",
                 "share_project_desc3": "For more information, visit the",
-                "share_project_desc4": "official ADNO documentation"
+                "share_project_desc4": "official Adno documentation"
             },
             "new_project": {
                 "add_infos_1": "Add information",
@@ -138,7 +138,7 @@
                 "no_title": "Please, add a name to your project",
                 "unable_reading_manifest": "Unable to read this manifest, please try again or choose another one",
                 "no_iiif": "Non-IIIF project detected, please fill in an IIIF project",
-                "wrong_file": "This file is not readable by ADNO! Please try again with another file"
+                "wrong_file": "This file is not readable by Adno! Please try again with another file"
             },
             "footer": "Poitiers. This project was supported by the French Ministry of Culture",
             "tags_infos": "Please press your key 'enter' between each tag to save them"

--- a/langs/fr.json
+++ b/langs/fr.json
@@ -119,7 +119,7 @@
                 "show_metadatas": "Voir les métadonnées",
                 "share_project": "Sauvegarde et partage du projet",
                 "share_project_desc1": "Téléchargez d’abord le fichier de votre projet. Pour le partager, vous pouvez, soit le transmettre par mail, soit le déposer en ligne — sur un site web, un serveur de fichiers ou sur le système de fichier interplanétaire IPFS —, puis diffuser son URL ou son CID IPFS.",
-                "share_project_desc2": "Dès lors que votre projet Adno est en ligne, il est possible de rendre visible dans une page web en insérant une balise iframe.",
+                "share_project_desc2": "Dès lors que votre projet Adno est en ligne, il est possible de le rendre visible dans une page web en insérant une balise iframe.",
                 "share_project_desc3": "Pour plus d'informations, rendez-vous sur la",
                 "share_project_desc4": "documentation officielle d'Adno"
             },

--- a/langs/fr.json
+++ b/langs/fr.json
@@ -18,7 +18,7 @@
                 "import_now": "directement",
                 "validate": "Valider l'importation",
                 "cancel": "Annuler l'importation",
-                "adno_project": "Projet ADNO détecté, voulez-vous l'importer ?",
+                "adno_project": "Projet Adno détecté, voulez-vous l'importer ?",
                 "import_success": "Projet importé avec succès"
             },
             "projects": {
@@ -40,7 +40,7 @@
                 "description": "Description",
                 "autor": "Auteur",
                 "editor": "Editeur",
-                "manifest_url": "URL du Manifeste",
+                "manifest_url": "URL",
                 "create": "Créer mon projet",
                 "back": "Retour",
                 "add_desc": "Description de votre projet (optionnel)",
@@ -102,10 +102,10 @@
                 "del_annotation_confirmation": "L'annotation a bien été supprimée",
                 "project_edit_success": "Projet édité avec succés !",
                 "settings_updated_success": "Paramètres mis à jour avec succés !",
-                "adno_proj_detected": "Projet ADNO détecté, voulez-vous l'importer ?",
+                "adno_proj_detected": "Projet Adno détecté, voulez-vous l'importer ?",
                 "old_version": "Un ou plusieurs projets ont été fait avec une version obsolète d’Adno",
                 "update_old_version": "Mettre à jour vers la dernière version",
-                "version_updated": "Félicitations, vos projets ADNO sont à jour !"
+                "version_updated": "Félicitations, vos projets Adno sont à jour !"
             },
             "annotation": {
                 "no_content": "aucun contenu",
@@ -117,11 +117,11 @@
                 "download_project": "Télécharger le projet",
                 "edit_project": "Edit the project",
                 "show_metadatas": "Voir les métadonnées",
-                "share_project": "Partage du projet",
-                "share_project_desc1": "Afin de pouvoir travailler de manière collaborative, vous devez télécharger le projet puis le partager à vos collaborateurs via un service comme IPFS, Google Drive ou WeTransfer.",
-                "share_project_desc2": "Ainsi, vos collaborateurs pourront importer le projet de leur côté afin de profiter de vos changements.",
+                "share_project": "Sauvegarde et partage du projet",
+                "share_project_desc1": "Téléchargez d’abord le fichier de votre projet. Pour le partager, vous pouvez, soit le transmettre par mail, soit le déposer en ligne — sur un site web, un serveur de fichiers ou sur le système de fichier interplanétaire IPFS —, puis diffuser son URL ou son CID IPFS.",
+                "share_project_desc2": "Dès lors que votre projet Adno est en ligne, il est possible de rendre visible dans une page web en insérant une balise iframe.",
                 "share_project_desc3": "Pour plus d'informations, rendez-vous sur la",
-                "share_project_desc4": "documentation officielle d'ADNO"
+                "share_project_desc4": "documentation officielle d'Adno"
             },
             "new_project": {
                 "add_infos_1": "Ajouter des renseignements",

--- a/src/components/Project/Navbar/Navbar.js
+++ b/src/components/Project/Navbar/Navbar.js
@@ -28,7 +28,7 @@ class Navbar extends Component {
                         <h3 className="font-bold text-lg">{this.props.t('navbar.share_project')}</h3>
                         <p className="py-4">{this.props.t('navbar.share_project_desc1')}</p>
                         <p className="py-4">{this.props.t('navbar.share_project_desc2')}</p>
-                        <p className="py-4">{this.props.t('navbar.share_project_desc3')} <a className="adno-link" href="https://adno.app/fr/docs/prologue/quick-start/" target="_blank">{this.props.t('navbar.share_project_desc4')}</a></p>
+                        <p className="py-4">{this.props.t('navbar.share_project_desc3')} <a className="adno-link" href="https://adno.app/" target="_blank">{this.props.t('navbar.share_project_desc4')}</a></p>
                         <div className="modal-action">
                             <label htmlFor="my-modal" className="btn">{this.props.t('buttons.cancel')}</label>
                             <label className="btn btn-success">


### PR DESCRIPTION
J'ai actualisé l'information de la fenêtre modale de téléchargement ainsi que quelques typos. 

J'ai aussi changé le lien vers la doc pour le renvoyer à la racine du site (pour éviter une éventuelle mauvaise orientation au niveau de la langue).

Il faudrait que cette fenêtre modale soit activée aussi dans l'écran d'accueil avec la liste des projets enregistrés dans le navigateur. 