### PR TITLE
add workflows for easy forking and deployment

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -1,0 +1,44 @@
+name: ADNO BUILD FULL
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build_app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Use YARN
+        uses: mskelton/setup-yarn@v1
+        with:
+          node-version: "16.x"
+      - name: Install dependencies
+        run: yarn install
+      - name: Generate build-light to create adno_light directory
+        env:
+          ADNO_MODE: FULL
+          GRANTED_IMG_EXTENSIONS: jpg,png,JPG,PNG
+          PUBLIC_URL: "/${{ github.event.repository.name }}"
+        run: yarn build-full
+      - name: Upload Artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "adno-full/"
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/light.yml
+++ b/.github/workflows/light.yml
@@ -1,0 +1,44 @@
+name: ADNO BUILD LIGHT
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build_app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Use YARN
+        uses: mskelton/setup-yarn@v1
+        with:
+          node-version: "16.x"
+      - name: Install dependencies
+        run: yarn install
+      - name: Generate build-light to create adno_light directory
+        env:
+          ADNO_MODE: LIGHT
+          GRANTED_IMG_EXTENSIONS: jpg,png,JPG,PNG
+          PUBLIC_URL: "/${{ github.event.repository.name }}"
+        run: yarn build-light
+      - name: Upload Artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "adno-light/"
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "adno-react",
   "version": "1.0.0",
+  "homepage": "https://dhbern.github.io/adno/",
   "description": "",
   "scripts": {
     "start": "yarn install && yarn clean && parcel public/index.html",
-    "build-full": "NODE_ENV=ADNOFULL parcel build public/index.html --dist-dir adno-full",
-    "build-light": "NODE_ENV=ADNOLIGHT parcel build public/index.html --dist-dir adno-light",
+    "build-full": "sh -c 'NODE_ENV=ADNOFULL parcel build public/index.html --dist-dir adno-full --public-url ${PUBLIC_URL:-/}'",
+    "build-light": "sh -c 'NODE_ENV=ADNOLIGHT parcel build public/index.html --dist-dir adno-light --public-url ${PUBLIC_URL:-/}'",
     "build": "yarn install && yarn clean && yarn build-full && yarn build-light",
     "clean": "rimraf .parcel-cache && rimraf dist && rimraf adno-full && rimraf adno-light",
     "clean-modules": "rm -r node_modules"


### PR DESCRIPTION
Hi Thierry

I added two workflows, one to build the full version and one to build the light version. They also deploy directly to gh-pages with no modification. They are triggered manually (via the actions tab), so the user can decide what version they want.

This should simplify forking the project. If this helps you, maybe you can update this in the _Host ADNO with Github Pages_ in the readme file?

Cheers

Sebi