### PR TITLE
Supression du français par défaut

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -49,8 +49,10 @@
                 "add_title": "Add a title to your project",
                 "copy": "copy",
                 "cancel": "Cancel",
-                "back_home": "Cancel and go back to homepage",
+		"choose": "Select an image",
+                "choose_desc": "Choose the image you want to use for your project",
                 "choose_canva": "Use this picture for my project",
+                "back_home": "Cancel and go back to homepage",
                 "metadatas": {
                     "identifier": "Identifier",
                     "source": "Source",

--- a/langs/fr.json
+++ b/langs/fr.json
@@ -49,8 +49,10 @@
                 "add_title": "Donnez un titre à votre projet",
                 "copy": "copie",
                 "cancel": "Annuler",
-                "back_home": "Annuler et revenir à l'accueil",
+                "choose": "Sélectionnez une image",
+                "choose_desc": "Choisissez l'image que vous souhaitez utiliser pour votre projet Adno",
                 "choose_canva": "Utiliser cette image pour mon projet",
+                "back_home": "Annuler et revenir à l'accueil",
                 "metadatas": {
                     "identifier": "Identifiant",
                     "source": "Source",

--- a/src/components/AdnoEditor/AdnoEditor.css
+++ b/src/components/AdnoEditor/AdnoEditor.css
@@ -114,7 +114,7 @@
     background: white;
     right: 0px;
     width: 300px;
-    opacity: 0.7;
+    opacity: 0.8;
 }
 
 .toolbar-with-metadatas{

--- a/src/components/AdnoEditor/AdnoEditor.css
+++ b/src/components/AdnoEditor/AdnoEditor.css
@@ -114,6 +114,7 @@
     background: white;
     right: 0px;
     width: 300px;
+    opacity: 0.7;
 }
 
 .toolbar-with-metadatas{

--- a/src/components/AdnoEditor/AdnoEditor.js
+++ b/src/components/AdnoEditor/AdnoEditor.js
@@ -61,7 +61,7 @@ class AdnoEditor extends Component {
             this.AdnoAnnotorious = OpenSeadragon.Annotorious(OpenSeadragon({
                 id: 'openseadragon1',
                 tileSources: tileSources,
-                prefixUrl: 'https://openseadragon.github.io/openseadragon/images/',
+                prefixUrl: 'https://cdn.jsdelivr.net/gh/Benomrans/openseadragon-icons@main/images/',
                 // Enable rotation
                 showRotationControl: this.props.rotation,
             }), {

--- a/src/components/AdnoEmbed/AdnoEmbed.js
+++ b/src/components/AdnoEmbed/AdnoEmbed.js
@@ -107,7 +107,7 @@ class AdnoEmbed extends Component {
             homeButton: "home-button",
             showNavigator: false,
             tileSources: tileSources,
-            prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
+            prefixUrl: "https://cdn.jsdelivr.net/gh/Benomrans/openseadragon-icons@main/images/",
         });
 
         OpenSeadragon.setString("Tooltips.FullPage", this.props.t('editor.fullpage'));

--- a/src/components/AdnoMarkdown/AdnoMdEditor.js
+++ b/src/components/AdnoMarkdown/AdnoMdEditor.js
@@ -35,7 +35,6 @@ class AdnoMdEditor extends Component {
 
     componentDidMount() {
         this.editor = new Editor({
-            language: 'fr-FR',
             el: document.querySelector('#editor'),
             initialValue: this.getAnnoBody(),
             previewStyle: "tab",

--- a/src/components/AdnoMarkdown/AdnoMdEditor.js
+++ b/src/components/AdnoMarkdown/AdnoMdEditor.js
@@ -37,14 +37,12 @@ class AdnoMdEditor extends Component {
         this.editor = new Editor({
             el: document.querySelector('#editor'),
             initialValue: this.getAnnoBody(),
-            previewStyle: "tab",
+            previewStyle: "vertical",
             height: "600px",
-            initialEditType: "markdown",
+            initialEditType: "wysiwyg",
             usageStatistics: false,
-            initialEditType: "markdown",
             placeholder: this.props.t("editor.placeholder"),
-            hideModeSwitch: true,
-            language: "fr-FR",
+            hideModeSwitch: false,
             toolbarItems: [[
                 "heading",
                 "italic",

--- a/src/components/AdnoViewer/AdnoViewer.js
+++ b/src/components/AdnoViewer/AdnoViewer.js
@@ -81,7 +81,7 @@ class AdnoViewer extends Component {
                 OpenSeadragon({
                     id: 'image_iiif',
                     tileSources: [JSON.parse(localStorage.getItem(this.props.match.params.id)).manifest_url],
-                    prefixUrl: 'https://openseadragon.github.io/openseadragon/images/'
+                    prefixUrl: 'https://cdn.jsdelivr.net/gh/Benomrans/openseadragon-icons@main/images/'
                 });
             } else {
                 OpenSeadragon({
@@ -90,7 +90,7 @@ class AdnoViewer extends Component {
                         type: 'image',
                         url: checkIfProjectExists(this.props.match.params.id) && JSON.parse(localStorage.getItem(this.props.match.params.id)).img_url
                     },
-                    prefixUrl: 'https://openseadragon.github.io/openseadragon/images/'
+                    prefixUrl: 'https://cdn.jsdelivr.net/gh/Benomrans/openseadragon-icons@main/images/'
                 });
             }
             OpenSeadragon.setString("Tooltips.FullPage", this.props.t('editor.fullpage'));

--- a/src/components/NewProject/NewProject.js
+++ b/src/components/NewProject/NewProject.js
@@ -420,8 +420,8 @@ class NewProject extends Component {
                 {
                     this.state.isCanvaProject && !this.state.selectedCanva && this.state.manifestImages && this.state.nbCanvases > 1 &&
                     <>
-                        <h1>Choisissez une image</h1>
-                        <p className="adno_description">Ce manifest comporte plusieurs images, vous devez en choisir une pour votre projet Adno</p>
+                        <h1>{this.props.t('project.choose')}</h1>
+                        <p className="adno_description">{this.props.t('project.choose_desc')}</p>
                     </>
                 }
 

--- a/src/components/OpenView/OpenView.js
+++ b/src/components/OpenView/OpenView.js
@@ -57,7 +57,7 @@ class OpenView extends Component {
                 homeButton: "home-button",
                 showNavigator: this.props.showNavigator,
                 tileSources: tileSources,
-                prefixUrl: 'https://openseadragon.github.io/openseadragon/images/'
+                prefixUrl: 'https://cdn.jsdelivr.net/gh/Benomrans/openseadragon-icons@main/images/'
             })
 
             OpenSeadragon.setString("Tooltips.FullPage", this.props.t('editor.fullpage'));

--- a/src/index.css
+++ b/src/index.css
@@ -54,8 +54,8 @@ ul {
 }
 
 #toolbar-container button.a9s-toolbar-btn {
-  margin: 0 4px 0 0;
-  padding: 8px;
+  margin: 0 4px 0 ;
+  padding: 4px;
   width: 40px;
   height: 40px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,13 @@ ul {
     background-position-y: 3px;
 }
 
+#toolbar-container button.a9s-toolbar-btn {
+  margin: 0 4px 0 0;
+  padding: 8px;
+  width: 40px;
+  height: 40px;
+}
+
 footer{
     position: fixed;
     top: calc(100vh - 52px)


### PR DESCRIPTION
Certains champs n'avait pas été traduits dans la saisie du projet et le français était la langue par défaut de l'éditeur 